### PR TITLE
fix(BBD 811): Search is broken or haunted 

### DIFF
--- a/src/details/index.ts
+++ b/src/details/index.ts
@@ -12,7 +12,7 @@ class Details {
   init() {
     const details = this.select(Selectors.details);
     if (details && details.data) {
-      this.product = <any>ProductTransformer.transform(details.data, this.structure);
+      this.updateDetails(details.data);
     }
     this.flux.on(Events.DETAILS_UPDATED, this.updateDetails);
   }

--- a/src/details/index.ts
+++ b/src/details/index.ts
@@ -11,13 +11,13 @@ class Details {
 
   init() {
     const details = this.select(Selectors.details);
-    if (details && details.product) {
-      this.updateProduct(details.product);
+    if (details && details.data) {
+      this.product = <any>ProductTransformer.transform(details.data, this.structure);
     }
-    this.flux.on(Events.DETAILS_PRODUCT_UPDATED, this.updateProduct);
+    this.flux.on(Events.DETAILS_UPDATED, this.updateDetails);
   }
 
-  updateProduct = (product: Store.Product) => {
+  updateDetails = (product: Store.Product) => {
     if (product) {
       this.update({ product: ProductTransformer.transform(product, this.structure) });
     } else {

--- a/test/unit/details.ts
+++ b/test/unit/details.ts
@@ -23,26 +23,26 @@ suite('Details', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlias
   });
 
   describe('init()', () => {
-    it('should listen for DETAILS_PRODUCT_UPDATED', () => {
+    it('should listen for DETAILS_UPDATED', () => {
       const on = spy();
       details.flux = <any>{ on };
       details.select = spy();
 
       details.init();
 
-      expect(on.calledWith(Events.DETAILS_PRODUCT_UPDATED, details.updateDetails));
+      expect(on.calledWith(Events.DETAILS_UPDATED, details.updateDetails));
     });
 
     it('should call details selector and call updateDetails with details.product', () => {
       const on = spy();
-      const product = { a: 1 };
+      const data = { a: 1 };
       const updateDetails = stub(details, 'updateDetails');
       details.flux = <any>{ on };
-      details.select = spy(() => ({ product }));
+      details.select = spy(() => ({ data }));
 
       details.init();
 
-      expect(updateDetails).to.be.calledWithExactly(product);
+      expect(updateDetails).to.be.calledWithExactly(data);
     });
   });
 

--- a/test/unit/details.ts
+++ b/test/unit/details.ts
@@ -30,30 +30,30 @@ suite('Details', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlias
 
       details.init();
 
-      expect(on.calledWith(Events.DETAILS_PRODUCT_UPDATED, details.updateProduct));
+      expect(on.calledWith(Events.DETAILS_PRODUCT_UPDATED, details.updateDetails));
     });
 
-    it('should call details selector and call updateProduct with details.product', () => {
+    it('should call details selector and call updateDetails with details.product', () => {
       const on = spy();
       const product = { a: 1 };
-      const updateProduct = stub(details, 'updateProduct');
+      const updateDetails = stub(details, 'updateDetails');
       details.flux = <any>{ on };
       details.select = spy(() => ({ product }));
 
       details.init();
 
-      expect(updateProduct).to.be.calledWithExactly(product);
+      expect(updateDetails).to.be.calledWithExactly(product);
     });
   });
 
-  describe('updateProduct()', () => {
+  describe('updateDetails()', () => {
     it('should update product', () => {
       const product: any = { a: 'b' };
       const transformed = { c: 'd' };
       const update = details.update = spy();
       const transform = stub(ProductTransformer, 'transform').returns(transformed);
 
-      details.updateProduct(product);
+      details.updateDetails(product);
 
       expect(update).to.be.calledWith({ product: transformed });
       expect(transform).to.be.calledWith(product, STRUCTURE);
@@ -64,7 +64,7 @@ suite('Details', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlias
       const update = details.update = spy();
       stub(ProductTransformer, 'transform').callsFake(() => expect.fail());
 
-      details.updateProduct(undefined);
+      details.updateDetails(undefined);
 
       expect(update).to.be.calledWith({ product: { data: {}, variants: [{}] } });
     });


### PR DESCRIPTION
Basically just changed this to use details.data instead of details.product.
Related:
* https://github.com/groupby/flux-capacitor/pull/127
* https://github.com/groupby/storefront-core/pull/139
* https://github.com/groupby/storefront-details/pull/18
* https://github.com/groupby/storefront-products/pull/26