### PR TITLE
fix(SF-1065): Remove padding from interpolated braces in the HTML templates

### DIFF
--- a/src/details/index.html
+++ b/src/details/index.html
@@ -1,3 +1,3 @@
-<gb-product if="{ state.product }" product="{ state.product }">
+<gb-product if="{state.product}" product="{state.product}">
   <yield/>
 </gb-product>


### PR DESCRIPTION
This fixes potential syntax errors coming from Riot.